### PR TITLE
Fix ending newline bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,5 @@ setup(
         "console_scripts": ["style50=style50.__main__:main"],
     },
     url="https://github.com/cs50/style50",
-    version="2.1.0"
+    version="2.1.1"
 )

--- a/style50/core.py
+++ b/style50/core.py
@@ -215,7 +215,7 @@ class Style50(object):
         """
         def fmt_html(content, dtype):
             content = cgi.escape(content, quote=True)
-            return content if dtype == " " else "<{1}><{0}></{1}>".format(content, "ins" if dtype == "+" else "del")
+            return content if dtype == " " else "<{1}>{0}</{1}>".format(content, "ins" if dtype == "+" else "del")
 
         return self._char_diff(old, new, fmt_html)
 

--- a/style50/core.py
+++ b/style50/core.py
@@ -177,6 +177,9 @@ class Style50(object):
         except KeyError:
             raise Error("unknown file type \"{}\", skipping...".format(file))
         else:
+            # Ensure file ends in a trailing newline for consistency
+            if code[-1] != "\n":
+                code += "\n"
             return check(code)
 
     @staticmethod
@@ -192,12 +195,6 @@ class Style50(object):
         Returns a generator yielding a unified diff between `old` and `new`.
         """
         # Add \n to end of file if it doesn't already have it
-        if old[-1] != "\n":
-            old += "\n"
-
-        if new[-1] != "\n":
-            new += "\n"
-
         for diff in difflib.ndiff(old.splitlines(True), new.splitlines(True)):
             if diff[0] == " ":
                 yield diff
@@ -222,13 +219,6 @@ class Style50(object):
         """
         def fmt_color(content, dtype):
             return termcolor.colored(content, None, "on_green" if dtype == "+" else "on_red" if dtype == "-" else None)
-
-        # Add \n to end of file if it doesn't already have it
-        if old[-1] != "\n":
-            old += "\n"
-
-        if new[-1] != "\n":
-            new += "\n"
 
         return self._char_diff(old, new, fmt_color)
 
@@ -288,6 +278,7 @@ class StyleCheck(object):
 
     def __init__(self, code):
         self.original = code
+
         comments = self.count_comments(code)
 
         try:

--- a/style50/core.py
+++ b/style50/core.py
@@ -110,7 +110,6 @@ class Style50(object):
             # Display results.
             if results.diffs:
                 print(*self.diff(results.original, results.styled), sep="",  end="")
-                print()
             else:
                 termcolor.cprint("no style errors found", "green")
 
@@ -192,6 +191,13 @@ class Style50(object):
         """
         Returns a generator yielding a unified diff between `old` and `new`.
         """
+        # Add \n to end of file if it doesn't already have it
+        if old[-1] != "\n":
+            old += "\n"
+
+        if new[-1] != "\n":
+            new += "\n"
+
         for diff in difflib.ndiff(old.splitlines(True), new.splitlines(True)):
             if diff[0] == " ":
                 yield diff
@@ -216,6 +222,14 @@ class Style50(object):
         """
         def fmt_color(content, dtype):
             return termcolor.colored(content, None, "on_green" if dtype == "+" else "on_red" if dtype == "-" else None)
+
+        # Add \n to end of file if it doesn't already have it
+        if old[-1] != "\n":
+            old += "\n"
+
+        if new[-1] != "\n":
+            new += "\n"
+
         return self._char_diff(old, new, fmt_color)
 
     @staticmethod

--- a/style50/core.py
+++ b/style50/core.py
@@ -167,20 +167,27 @@ class Style50(object):
         _, extension = os.path.splitext(file)
         try:
             check = self.extension_map[extension[1:]]
+
             with open(file) as f:
                 code = f.read()
+
         except (OSError, IOError) as e:
             if e.errno == errno.ENOENT:
                 raise Error("file \"{}\" not found".format(file))
             else:
                 raise
-        except KeyError:
+        except (KeyError, IndexError):
             raise Error("unknown file type \"{}\", skipping...".format(file))
-        else:
-            # Ensure file ends in a trailing newline for consistency
+
+        # Ensure file ends in a trailing newline for consistency
+        try:
             if code[-1] != "\n":
                 code += "\n"
+        except IndexError:
+            raise Error("file is empty")
+        else:
             return check(code)
+
 
     @staticmethod
     def split_diff(old, new):
@@ -194,7 +201,6 @@ class Style50(object):
         """
         Returns a generator yielding a unified diff between `old` and `new`.
         """
-        # Add \n to end of file if it doesn't already have it
         for diff in difflib.ndiff(old.splitlines(True), new.splitlines(True)):
             if diff[0] == " ":
                 yield diff

--- a/style50/core.py
+++ b/style50/core.py
@@ -110,6 +110,7 @@ class Style50(object):
             # Display results.
             if results.diffs:
                 print(*self.diff(results.original, results.styled), sep="",  end="")
+                print()
             else:
                 termcolor.cprint("no style errors found", "green")
 


### PR DESCRIPTION
`style50` will sometimes not print the trailing newline after the diff. This PR addresses that bug, #6.