### PR TITLE
fixed jsbeautifier version for now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
         "Topic :: Utilities"
     ],
     description="This is style50, with which code can be checked against the CS50 style guide",
-    install_requires=["argparse", "autopep8", "icdiff", "jsbeautifier", "six", "termcolor"],
+    install_requires=["argparse", "autopep8", "icdiff", "jsbeautifier==1.6.14", "six", "termcolor"],
     dependency_links=["git+https://github.com/jeffkaufman/icdiff.git"],
     keywords=["style", "style50"],
     name="style50",
@@ -20,5 +20,5 @@ setup(
         "console_scripts": ["style50=style50.__main__:main"],
     },
     url="https://github.com/cs50/style50",
-    version="2.1.4"
+    version="2.1.5"
 )


### PR DESCRIPTION
Apparently the latest version of jsbeautifier is buggy, breaking installation of `style50`. Specified fixed version for now:

```
$ pip install jsbeautifier
Collecting jsbeautifier
  Downloading jsbeautifier-1.7.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-xiod3y70/jsbeautifier/setup.py", line 6, in <module>
        from jsbeautifier.__version__ import __version__
      File "/tmp/pip-build-xiod3y70/jsbeautifier/jsbeautifier/__init__.py", line 11, in <module>
        from jsbeautifier.javascript.options import BeautifierOptions
    ImportError: No module named 'jsbeautifier.javascript'
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-xiod3y70/jsbeautifier/
```