### PR TITLE
Added --ignore to allow paths to be ignored when style50 runs recursively

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Along with most of CS50's command line tools, `style50` supports being run on Wi
 ## Usage
 
 ```
-usage: style50 [-h] [-o MODE] [-v] [-V] [-E] FILE [FILE ...]
+usage: style50 [-h] [-o MODE] [-v] [-V] [-E] [-i PATTERN] FILE [FILE ...]
 
 positional arguments:
   FILE                  file or directory to lint
@@ -27,6 +27,8 @@ optional arguments:
   -V, --version         show program's version number and exit
   -E, --extensions      print supported file extensions (as JSON list) and
                         exit
+  -i PATTERN, --ignore PATTERN
+                        paths/patterns to be ignored
 ```
 
 `character`, `split`, and `unified` modes output character-based, side-by-side, and unified (respectively) diffs between the inputted file and the correctly styled version. `score` outputs the raw percentage of correct (unchanged) lines, while `json` outputs a json object containing information pertinent to the CS50 IDE plugin (coming soon).

--- a/style50/__main__.py
+++ b/style50/__main__.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 from __future__ import division
 
 import json
+import os
 import signal
 import sys
 import traceback
@@ -60,9 +61,13 @@ def main():
     parser.add_argument("-E", "--extensions", action="version",
                         version=json.dumps(list(Style50.extension_map.keys())),
                         help="print supported file extensions (as JSON list) and exit")
+    parser.add_argument("-i", "--ignore", action="append",
+                        help="paths to be ignored")
+
 
     main.args = parser.parse_args()
-    Style50(main.args.file, output=main.args.output).run()
+    ignore = main.args.ignore or filter(None, os.getenv("STYLE50_IGNORE", "").split(","))
+    Style50(main.args.file, ignore=ignore, output=main.args.output).run()
 
 
 # Necessary so `console_scripts` can extract the main function

--- a/style50/__main__.py
+++ b/style50/__main__.py
@@ -64,7 +64,6 @@ def main():
     parser.add_argument("-i", "--ignore", action="append",
                         help="paths to be ignored")
 
-
     main.args = parser.parse_args()
     ignore = main.args.ignore or filter(None, os.getenv("STYLE50_IGNORE", "").split(","))
     Style50(main.args.file, ignore=ignore, output=main.args.output).run()

--- a/style50/__main__.py
+++ b/style50/__main__.py
@@ -61,8 +61,8 @@ def main():
     parser.add_argument("-E", "--extensions", action="version",
                         version=json.dumps(list(Style50.extension_map.keys())),
                         help="print supported file extensions (as JSON list) and exit")
-    parser.add_argument("-i", "--ignore", action="append",
-                        help="paths to be ignored")
+    parser.add_argument("-i", "--ignore", action="append", metavar="PATTERN",
+                        help="paths/patterns to be ignored")
 
     main.args = parser.parse_args()
     ignore = main.args.ignore or filter(None, os.getenv("STYLE50_IGNORE", "").split(","))

--- a/style50/style50.py
+++ b/style50/style50.py
@@ -6,6 +6,7 @@ import cgi
 import errno
 import difflib
 import fcntl
+import fnmatch
 import itertools
 import json
 import os
@@ -61,9 +62,10 @@ class Style50(object):
 
     def __init__(self, paths, ignore=[], output="character"):
         try:
-            ignore = [re.compile(i) for i in ignore]
+            # Translate each ignore pattern into a regex and compile it
+            ignore = [re.compile(fnmatch.translate(i)) for i in ignore]
         except re.error:
-            raise Error("failed to parse regular expression")
+            raise Error("failed to parse ignore pattern")
 
         # Creates a generator of all the files found recursively in `paths`, filtering out any ignored paths.
         self.files = filter(lambda p: not any(reg.match(p) for reg in ignore),

--- a/style50/style50.py
+++ b/style50/style50.py
@@ -59,14 +59,21 @@ class Style50(object):
     # Dict that maps substrings of libmagic's outputs to classes. Used as fallback when file extension unrecognized
     magic_map = {}
 
-    def __init__(self, paths, output="character"):
-        # Creates a generator of all the files found recursively in `paths`.
-        self.files = itertools.chain.from_iterable(
-            [path] if not os.path.isdir(path)
-            else (os.path.join(root, file)
-                  for root, _, files in os.walk(path)
-                  for file in files)
-            for path in paths)
+    def __init__(self, paths, ignore=[], output="character"):
+
+        try:
+            ignore = [re.compile(i) for i in ignore]
+        except re.error:
+            raise Error("failed to parse regular expression")
+
+        # Creates a generator of all the files found recursively in `paths`, filtering out any ignored paths.
+        self.files = filter(lambda p: not any(reg.match(p) for reg in ignore),
+            itertools.chain.from_iterable(
+                [path] if not os.path.isdir(path)
+                else (os.path.join(root, file)
+                      for root, _, files in os.walk(path)
+                      for file in files)
+                for path in paths))
 
         # Set run function as apropriate for output mode.
         if output == "score":

--- a/style50/style50.py
+++ b/style50/style50.py
@@ -60,7 +60,6 @@ class Style50(object):
     magic_map = {}
 
     def __init__(self, paths, ignore=[], output="character"):
-
         try:
             ignore = [re.compile(i) for i in ignore]
         except re.error:
@@ -68,12 +67,11 @@ class Style50(object):
 
         # Creates a generator of all the files found recursively in `paths`, filtering out any ignored paths.
         self.files = filter(lambda p: not any(reg.match(p) for reg in ignore),
-            itertools.chain.from_iterable(
-                [path] if not os.path.isdir(path)
-                else (os.path.join(root, file)
-                      for root, _, files in os.walk(path)
-                      for file in files)
-                for path in paths))
+                            itertools.chain.from_iterable([path] if not os.path.isdir(path)
+                                                          else (os.path.join(root, file)
+                                                                for root, _, files in os.walk(path)
+                                                                for file in files)
+                                                          for path in paths))
 
         # Set run function as apropriate for output mode.
         if output == "score":


### PR DESCRIPTION
Usage:

    STYLE50_IGNORE='.*/\.c9/.*' style50 .

or equivalently

    style50 --ignore '.*/\.c9/.*

The command line option always takes precedence over the environment variable.

Multiple patterns can be specified as well. For the environment variable one can specify a comma delimited list e.g., `STYLE50_IGNORE="foo,bar,baz"` (though this does present an issue if the file has a comma in its name). The command line option may be specified multiple times e.g. `style50 --ignore "foo" --ignore "bar" --ignore "baz" .` This feature isn't strictly necessary since the notion of multiple patterns could be encoded using the `|` metacharacter in the regex, but it felt like a nice to have. 

If we decide to go with this method, we'd want to add the `STYLE50_IGNORE` environment variable for the `.c9` directory as above to the students' profile. cc @kzidane 

Resolves #55 