### PR TITLE
Trim white space around brackets

### DIFF
--- a/style50/languages.py
+++ b/style50/languages.py
@@ -15,7 +15,7 @@ class C(StyleCheck):
 
     astyle = [
         "astyle", "--ascii", "--add-braces", "--break-one-line-headers",
-        "--align-pointer=name", "--pad-comma",
+        "--align-pointer=name", "--pad-comma", "--unpad-paren",
         "--pad-header", "--pad-oper", "--max-code-length=100",
         "--convert-tabs", "--indent=spaces=4",
         "--indent-continuation=1", "--indent-switches",


### PR DESCRIPTION
Add `--unpad-paren` flag to `astyle` to trim withe space in source code

fixes #61