### PR TITLE
Changed line length + disable astyle option file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,5 @@ setup(
         "console_scripts": ["style50=style50.__main__:main"],
     },
     url="https://github.com/cs50/style50",
-    version="2.4.0"
+    version="2.4.1"
 )

--- a/style50/languages.py
+++ b/style50/languages.py
@@ -16,11 +16,11 @@ class C(StyleCheck):
     astyle = [
         "astyle", "--ascii", "--add-braces", "--break-one-line-headers",
         "--align-pointer=name", "--pad-comma",
-        "--pad-header", "--pad-oper", "--max-code-length=100",
+        "--pad-header", "--pad-oper", "--max-code-length=132",
         "--convert-tabs", "--indent=spaces=4",
         "--indent-continuation=1", "--indent-switches",
         "--lineend=linux", "--min-conditional-indent=1",
-        "--style=allman"
+        "--options=none", "--style=allman"
     ]
 
     # Match (1) /**/ comments, and (2) // comments.
@@ -81,7 +81,7 @@ class Python(StyleCheck):
 
     # TODO: Determine which options (if any) should be passed to autopep8
     def style(self, code):
-        return autopep8.fix_code(code, options={"max_line_length": 100, "ignore_local_config": True})
+        return autopep8.fix_code(code, options={"max_line_length": 132, "ignore_local_config": True})
 
 
 class Js(C):


### PR DESCRIPTION
Changes max line length for both C and Python to 132 chars.

Also adds `--options=none` to astyle flags to make sure a local astyle config file doesn't change style50's output. This already exists for Python checks in the form of "ignore_local_opts", and was an oversight not to have it for the C checks as well.