### PR TITLE
reenable E226

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,5 @@ setup(
         "console_scripts": ["style50=style50.__main__:main"],
     },
     url="https://github.com/cs50/style50",
-    version="2.4.1"
+    version="2.4.2"
 )

--- a/style50/languages.py
+++ b/style50/languages.py
@@ -81,12 +81,17 @@ class Python(StyleCheck):
 
     # TODO: Determine which options (if any) should be passed to autopep8
     def style(self, code):
-        return autopep8.fix_code(code, options={"max_line_length": 132, "ignore_local_config": True})
+        ignore = autopep8.DEFAULT_IGNORE.split(",")
+        try:
+            ignore.remove("E226") # Don't ignore unpadded operators
+        except ValueError:
+            pass
+        return autopep8.fix_code(code, options={"max_line_length": 132, "ignore_local_config": True, "ignore": ignore})
 
 
 class Js(C):
     # Disable JS until we settle on a style guide for it
-    extensions =  [] # ["js"]
+    extensions = []  # ["js"]
     magic_names = []
 
     # Taken from http://code.activestate.com/recipes/496882-javascript-code-compression/


### PR DESCRIPTION
Per slack discussion. autopep8 1.3.4 disables enforcing padding around binary operators by default, since PEP8 does not strictly require this. To maintain consistency with C however, style50 should probably still support this (although it does mean deviating from PEP8 a little bit). [Relevant autopep8 issue.](https://github.com/hhatto/autopep8/issues/330).