### PR TITLE
Re-add javascript

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
-- '2.7'
-- '3.4'
+- '3.6'
 branches:
   except: "/^v\\d/"
 install: pip install .

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Along with most of CS50's command line tools, `style50` supports being run on Wi
 ## Usage
 
 ```
-usage: style50 [-h] [-o MODE] [-v] [-V] [-E] [-i PATTERN] FILE [FILE ...]
+usage: style50 [-h] [-o MODE] [-v] [-V] [-E] [-i PATTERN] file [file ...]
 
 positional arguments:
-  FILE                  file or directory to lint
+  file                  file or directory to lint
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -28,7 +28,6 @@ optional arguments:
   -E, --extensions      print supported file extensions (as JSON list) and
                         exit
   -i PATTERN, --ignore PATTERN
-                        paths/patterns to be ignored
 ```
 
 `character`, `split`, and `unified` modes output character-based, side-by-side, and unified (respectively) diffs between the inputted file and the correctly styled version. `score` outputs the raw percentage of correct (unchanged) lines, while `json` outputs a json object containing information pertinent to the CS50 IDE plugin (coming soon).

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ optional arguments:
   -E, --extensions      print supported file extensions (as JSON list) and
                         exit
   -i PATTERN, --ignore PATTERN
+                        paths/patterns to be ignored
 ```
 
 `character`, `split`, and `unified` modes output character-based, side-by-side, and unified (respectively) diffs between the inputted file and the correctly styled version. `score` outputs the raw percentage of correct (unchanged) lines, while `json` outputs a json object containing information pertinent to the CS50 IDE plugin (coming soon).

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
         "Topic :: Utilities"
     ],
     description="This is style50, with which code can be checked against the CS50 style guide",
-    install_requires=["argparse", "autopep8>=1.3.3", "icdiff", "jsbeautifier==1.6.14", "python-magic", "six", "termcolor"],
+    install_requires=["argparse", "autopep8>=1.3.3", "icdiff", "jsbeautifier", "python-magic", "termcolor"],
     dependency_links=["git+https://github.com/jeffkaufman/icdiff.git"],
     keywords=["style", "style50"],
     name="style50",

--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,11 @@ setup(
     keywords=["style", "style50"],
     name="style50",
     license="MIT",
+    py_requires=">=3.6",
     packages=find_packages(),
     entry_points={
         "console_scripts": ["style50=style50.__main__:main"],
     },
     url="https://github.com/cs50/style50",
-    version="2.5.0"
+    version="2.6.0"
 )

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(
     dependency_links=["git+https://github.com/jeffkaufman/icdiff.git"],
     keywords=["style", "style50"],
     name="style50",
-    license="MIT",
     py_requires=">=3.6",
     license="GPLv3",
     packages=find_packages(),

--- a/style50/languages.py
+++ b/style50/languages.py
@@ -81,17 +81,11 @@ class Python(StyleCheck):
 
     # TODO: Determine which options (if any) should be passed to autopep8
     def style(self, code):
-        ignore = autopep8.DEFAULT_IGNORE.split(",")
-        try:
-            ignore.remove("E226") # Don't ignore unpadded operators
-        except ValueError:
-            pass
-        return autopep8.fix_code(code, options={"max_line_length": 132, "ignore_local_config": True, "ignore": ignore})
+        return autopep8.fix_code(code, options={"max_line_length": 132, "ignore_local_config": True})
 
 
 class Js(C):
-    # Disable JS until we settle on a style guide for it
-    extensions = []  # ["js"]
+    extensions = ["js"]
     magic_names = []
 
     # Taken from http://code.activestate.com/recipes/496882-javascript-code-compression/
@@ -109,6 +103,10 @@ class Js(C):
     def style(self, code):
         opts = jsbeautifier.default_options()
         opts.end_with_newline = True
+        opts.operator_position = "preserve-newline"
+        opts.wrap_line_length = 132
+        opts.brace_style = "collapse,preserve-inline"
+        opts.keep_array_indentation = True
         return jsbeautifier.beautify(code, opts)
 
 

--- a/style50/languages.py
+++ b/style50/languages.py
@@ -75,7 +75,7 @@ class Python(StyleCheck):
     def count_lines(self, code):
         """
         count_lines ignores blank lines by default,
-        but blank lines are relavent to style per pep8
+        but blank lines are relevant to style per pep8
         """
         return len(code.splitlines())
 

--- a/style50/style50.py
+++ b/style50/style50.py
@@ -1,4 +1,4 @@
-from abc import ABCMeta, abstractmethod, abstractproperty
+from abc import ABCMeta, abstractmethod
 import cgi
 import errno
 import difflib
@@ -395,7 +395,8 @@ class StyleCheck(metaclass=StyleMeta):
         Returns number of coments in `code`. If not implemented by child, will not warn about comments.
         """
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def extensions(self):
         """
         List of file extensions that check should be run on.

--- a/style50/style50.py
+++ b/style50/style50.py
@@ -151,7 +151,7 @@ class Style50:
                     "diff": "<pre>{}</pre>".format("\n".join(self.html_diff(results.original, results.styled))),
                 }
 
-        json.dump(checks, sys.stdout)
+        json.dump(checks, sys.stdout, indent=4)
 
     def run_score(self):
         """

--- a/style50/style50.py
+++ b/style50/style50.py
@@ -357,7 +357,7 @@ class StyleCheck(metaclass=StyleMeta):
 
         self.lines = self.count_lines(self.styled)
         try:
-            self.score = 1 - self.diffs / self.lines
+            self.score = min(1 - self.diffs / self.lines, 0)
         except ZeroDivisionError:
             raise Error("file is empty")
 

--- a/style50/style50.py
+++ b/style50/style50.py
@@ -152,6 +152,7 @@ class Style50:
                 }
 
         json.dump(checks, sys.stdout, indent=4)
+        print()
 
     def run_score(self):
         """
@@ -395,7 +396,6 @@ class StyleCheck(metaclass=StyleMeta):
         Returns number of coments in `code`. If not implemented by child, will not warn about comments.
         """
 
-    @property
     @abstractmethod
     def extensions(self):
         """


### PR DESCRIPTION
This PR re-enables Javascript support in `style50`. The underlying tool is [js-beautify](https://github.com/beautify-web/js-beautify). `js-beautify` is not super great at documenting what beautification they actually do, outside of the configurable options. For example, it pads operands with spaces `1+1` => `1 + 1` but this isn't really documented anywhere, since it is not configurable. Same goes for padding inline objects with spaces e.g. `{foo:bar}` => `{ foo:  bar }` and padding around commas e.g. `f(a,b)` => `f(a, b)` I haven't found any real controversial changes that are not configurable, but I'm sure I don't have a 100% complete list.  Additionally, 


That said, I'll quickly run through the relavent lints that `js-beautify` documents, the options I've enabled, and whether/why it is a deviation from their defaults.

* Indent with 4 spaces (default)
* Don't pad parens, e.g. `f( a, b )` => `f(a, b)` and `f( )` => `f()` (default). 
* No padding in anonymous functions e.g. `function ()` => `function()`. (default)
* "Collapsed" braces (aka first brace on same  line). (default)
* Preserve inline functions e.g., don't force e.g. `let inc = function(x) { return x + 1; }`  to be multiple lines. This is not what `js-beautify` does by default, but it seems presumptuous of us to say that this _always_ bad style. The length of these functions is limited by the max line count anyway.
* Preserve array indentation. This is not the default, but without this option, `js-beautify` will turn e.g.

```
let arr = [1,2,3,
           4,5,6]
```
into 
```
let arr = [1,2,3,
          4,5,6]
```
which seems presumptuous and IMO actually looks a bit worse.
* Wrap lines at 132 characters. `js-beautify` does not wrap lines at all by default but seems better to override this for consistency with C and Python.
* Don't remove `\n` from last line in file. By default `js-beautify` will remove the `\n` from the end of the last line, but many text editors automatically add this and  POSIX specifies that `\n` is a _line terminator_ not a _line delimiter_ and therefore the last line should end in `\n`.
* Preserve newlines around operators. By default `js-beautify`, will always put the operator before the newline so it will turn e.g. this:
```
let x = 1 + 2
          - 3;
```
into

```
let x = 1 + 2 -
            3;
```
which seems (a) presumptuous and (b) worse style than the original since conceptually the `-` and `+` act more like a sign on the second argument. We could have `js-beautify` always convert the latter into the former (which I would consider better style), but maybe this is too presumptuous. I've set it to just leave it however the student wrote it currently.


Thoughts?

Additionally, this PR also changes how `style50` displays removed newlines. This rarely showed up before since our bracing style usually caused newlines to be added to students' code, but now removed newlines are seemingly more common. Before, `style50` would display the red `\n`, but would still actually print a newline, so e.g.

```
function hello(name)
{
    console.log("hello, " + name)
}
```

would result in
![screenshot from 2018-06-24 15-27-26](https://user-images.githubusercontent.com/3654575/41822795-54eeab6e-77c3-11e8-9af4-7df6cd800f12.png)

This seems kinda confusing because `style50` is telling you to remove a newline but the output still shows the `function` and the `{` on separate lines. After the change, the output looks like this:

![screenshot from 2018-06-24 15-30-24](https://user-images.githubusercontent.com/3654575/41822806-951ecb06-77c3-11e8-8480-c3cd37720954.png)

which seems more clear to me. 

Thoughts on this?
