### PR TITLE
v2.6.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
         "Topic :: Utilities"
     ],
     description="This is style50, with which code can be checked against the CS50 style guide",
-    install_requires=["argparse", "autopep8>=1.3.3", "icdiff", "jsbeautifier", "python-magic", "termcolor"],
+    install_requires=["argparse", "autopep8>=1.4.3", "icdiff", "jsbeautifier", "python-magic", "termcolor"],
     dependency_links=["git+https://github.com/jeffkaufman/icdiff.git"],
     keywords=["style", "style50"],
     name="style50",
@@ -21,5 +21,5 @@ setup(
         "console_scripts": ["style50=style50.__main__:main"],
     },
     url="https://github.com/cs50/style50",
-    version="2.6.4"
+    version="2.6.5"
 )

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,5 @@ setup(
         "console_scripts": ["style50=style50.__main__:main"],
     },
     url="https://github.com/cs50/style50",
-    version="2.6.5"
+    version="2.6.6"
 )

--- a/style50/_api.py
+++ b/style50/_api.py
@@ -1,9 +1,9 @@
 from abc import ABCMeta, abstractmethod
-import cgi
 import errno
 import difflib
 import fcntl
 import fnmatch
+import html
 import itertools
 import json
 import os
@@ -247,7 +247,7 @@ class Style50:
                 tags.append("<{}{}>".format(tag[0], "ins" if tag[1] == "+" else "del"))
             return "".join(tags)
 
-        return self._char_diff(old, new, html_transition, fmt=cgi.escape)
+        return self._char_diff(old, new, html_transition, fmt=html.escape)
 
     def char_diff(self, old, new):
         """


### PR DESCRIPTION
Up autopep8 version per #83 and replace `cgi.escape` with `html.escape` since `cgi.escape` was [deprecated](https://docs.python.org/3/library/cgi.html#cgi.escape) in Python 3.2.